### PR TITLE
initial size adjustments; no items h2 for att

### DIFF
--- a/app/inst/www/js/ui/controls/breadcrumb.js
+++ b/app/inst/www/js/ui/controls/breadcrumb.js
@@ -39,7 +39,7 @@ define(['rcap/js/ui/controls/gridControl',
                     controlCategory: 'Navigation',
                     label: 'Breadcrumb',
                     icon: 'ellipsis-horizontal',
-                    initialSize: [2, 1],
+                    initialSize: [4, 2],
                     controlProperties: [
                         new TextControlProperty({
                             uid: 'textPrefix',

--- a/app/inst/www/js/ui/controls/dataTable.js
+++ b/app/inst/www/js/ui/controls/dataTable.js
@@ -16,7 +16,7 @@ define(['rcap/js/ui/controls/gridControl',
                 controlCategory: 'Dynamic',
                 label: 'Data Table',
                 icon: 'table',
-                initialSize: [2, 2],
+                initialSize: [4, 4],
                 controlProperties: [
                     new AutocompleteControlProperty({
                         uid: 'code',

--- a/app/inst/www/js/ui/controls/form.js
+++ b/app/inst/www/js/ui/controls/form.js
@@ -16,7 +16,7 @@ define(['rcap/js/ui/controls/gridControl',
                 controlCategory: 'HTML',
                 label: 'Form',
                 icon: 'list-alt',
-                initialSize: [2, 1],
+                initialSize: [4, 2],
                 controlProperties: [
 
                 ]

--- a/app/inst/www/js/ui/controls/gridControl.js
+++ b/app/inst/www/js/ui/controls/gridControl.js
@@ -55,7 +55,7 @@ define(['rcap/js/ui/controls/baseControl',
                 })
             ];
 
-            this.initialSize = options.initialSize || [2, 1];
+            this.initialSize = options.initialSize || [4, 2];
             this.width = +this.initialSize[0];
             this.height = +this.initialSize[1];
             this.controlProperties = options.controlProperties;

--- a/app/inst/www/js/ui/controls/iframe.js
+++ b/app/inst/www/js/ui/controls/iframe.js
@@ -19,7 +19,7 @@ define(['rcap/js/ui/controls/gridControl',
                 controlCategory: 'HTML',
                 label: 'iFrame',
                 icon: 'cloud',
-                initialSize: [2, 2],
+                initialSize: [4, 4],
                 controlProperties: [
                     new AutocompleteControlProperty({
                         uid: 'source',

--- a/app/inst/www/js/ui/controls/image.js
+++ b/app/inst/www/js/ui/controls/image.js
@@ -11,7 +11,7 @@ define(['rcap/js/ui/controls/gridControl', 'rcap/js/ui/controls/properties/textC
 				controlCategory: 'HTML',
 				label : 'Image',
 				icon: 'picture',
-				initialSize: [2, 2],
+				initialSize: [4, 4],
 				controlProperties: [
 					new TextControlProperty({
 						uid: 'imagesource',

--- a/app/inst/www/js/ui/controls/interactivePlot.js
+++ b/app/inst/www/js/ui/controls/interactivePlot.js
@@ -14,7 +14,7 @@ define(['rcap/js/ui/controls/gridControl',
                 controlCategory: 'Dynamic',
                 label: 'Interactive Plot',
                 icon: 'bar-chart',
-                initialSize: [2, 2],
+                initialSize: [4, 4],
                 controlProperties: [
                     new AutocompleteControlProperty({
                         uid: 'code',

--- a/app/inst/www/js/ui/controls/leaflet.js
+++ b/app/inst/www/js/ui/controls/leaflet.js
@@ -17,7 +17,7 @@ define(['rcap/js/ui/controls/gridControl',
                 controlCategory: 'Dynamic',
                 label: 'Leaflet',
                 icon: 'map-marker',
-                initialSize: [2, 2],
+                initialSize: [4, 4],
                 controlProperties: [
                     new AutocompleteControlProperty({
                         uid: 'code',

--- a/app/inst/www/js/ui/controls/pageMenu.js
+++ b/app/inst/www/js/ui/controls/pageMenu.js
@@ -94,7 +94,7 @@ define(['rcap/js/ui/controls/gridControl',
                 controlCategory: 'Navigation',
                 label: 'Page Menu',
                 icon: 'reorder',
-                initialSize: [2, 1],
+                initialSize: [4, 2],
                 controlProperties: [
                     new DropdownControlProperty({
                         uid: 'menustyle',

--- a/app/inst/www/js/ui/controls/rPlot.js
+++ b/app/inst/www/js/ui/controls/rPlot.js
@@ -15,7 +15,7 @@ define(['rcap/js/ui/controls/gridControl',
                 controlCategory: 'Dynamic',
                 label: 'R Plot',
                 icon: 'signal',
-                initialSize: [2, 2],
+                initialSize: [4, 4],
                 controlProperties: [
                     new AutocompleteControlProperty({
                         uid: 'code',

--- a/app/inst/www/js/ui/controls/rText.js
+++ b/app/inst/www/js/ui/controls/rText.js
@@ -14,7 +14,7 @@ define(['rcap/js/ui/controls/gridControl',
                 controlCategory: 'Dynamic',
                 label: 'R Text',
                 icon: 'edit',
-                initialSize: [2, 2],
+                initialSize: [4, 4],
                 controlProperties: [
                     new AutocompleteControlProperty({
                         uid: 'code',

--- a/app/inst/www/js/ui/controls/text.js
+++ b/app/inst/www/js/ui/controls/text.js
@@ -11,7 +11,7 @@ define(['rcap/js/ui/controls/gridControl',
 				controlCategory: 'HTML',
 				label : 'Text',
 				icon: 'pencil',
-				initialSize: [2, 2],
+				initialSize: [4, 4],
 				controlProperties: [
 					new WysiwygControlProperty({
 						uid: 'content',

--- a/app/inst/www/partials/designer.htm
+++ b/app/inst/www/partials/designer.htm
@@ -21,7 +21,7 @@
         <div class="stage" id="rcap-stage">
             <div id="inner-stage">
                 <div id="no-items" style="display:none">
-                    <h2>This page is empty</h2>
+                    <h2 id="empty-page-header">This page is empty</h2>
                     <p>Drag an item from the controls menu onto the page to get started</p>
                 </div>
             </div>

--- a/app/inst/www/styles/default.css
+++ b/app/inst/www/styles/default.css
@@ -2703,7 +2703,8 @@ table.dataTable td {
       position: relative;
       margin: 15px;
       padding-top: 10px;
-      padding-bottom: 10px; }
+      padding-bottom: 10px;
+      background-color: white; }
   #rcap-designer .style-details {
     padding-top: 15px;
     margin-top: 30px; }

--- a/app/inst/www/styles/default.scss
+++ b/app/inst/www/styles/default.scss
@@ -630,6 +630,7 @@
             margin: 15px;
             padding-top: 10px;
             padding-bottom: 10px;
+            background-color: white;
         }
     }
 

--- a/app/inst/www/themes/att/att.css
+++ b/app/inst/www/themes/att/att.css
@@ -29,7 +29,7 @@ $attDarkBlueHighlight:          #020bb3;
     margin-top: 150px;
     padding-bottom: 250px;
     border: none; }
-  #rcap-designer #inner-stage h2, #rcap-viewer #inner-stage h2 {
+  #rcap-designer #inner-stage h2:not(#empty-page-header), #rcap-viewer #inner-stage h2:not(#empty-page-header) {
     color: white;
     background: #009fdb;
     padding: 10px;
@@ -38,7 +38,7 @@ $attDarkBlueHighlight:          #020bb3;
     background: linear-gradient(to right, #009fdb 0%, #71c5e8 100%);
     border-bottom-right-radius: 25px;
     border-top: 5px solid #009fdb; }
-    #rcap-designer #inner-stage h2 a:link, #rcap-designer #inner-stage h2 a:visited, #rcap-designer #inner-stage h2 a:active, #rcap-designer #inner-stage h2 a:hover, #rcap-viewer #inner-stage h2 a:link, #rcap-viewer #inner-stage h2 a:visited, #rcap-viewer #inner-stage h2 a:active, #rcap-viewer #inner-stage h2 a:hover {
+    #rcap-designer #inner-stage h2:not(#empty-page-header) a:link, #rcap-designer #inner-stage h2:not(#empty-page-header) a:visited, #rcap-designer #inner-stage h2:not(#empty-page-header) a:active, #rcap-designer #inner-stage h2:not(#empty-page-header) a:hover, #rcap-viewer #inner-stage h2:not(#empty-page-header) a:link, #rcap-viewer #inner-stage h2:not(#empty-page-header) a:visited, #rcap-viewer #inner-stage h2:not(#empty-page-header) a:active, #rcap-viewer #inner-stage h2:not(#empty-page-header) a:hover {
       color: white;
       text-decoration: none; }
   #rcap-designer #inner-stage form, #rcap-viewer #inner-stage form {

--- a/app/inst/www/themes/att/att.scss
+++ b/app/inst/www/themes/att/att.scss
@@ -25,7 +25,7 @@
             border: none;
         }
 
-        & h2 {
+        & h2:not(#empty-page-header) {
             color: white;
             background: $attBlue;
             padding: 10px;


### PR DESCRIPTION
This adjusts the initial size of the controls based on the doubling in rows and columns of the grid.
AT&T Kiosk styling changes for 'no items' in designer.
