### PR TITLE
Form delete (from control dialog) now works, message fixed

### DIFF
--- a/app/inst/www/js/ui/dialogManager.js
+++ b/app/inst/www/js/ui/dialogManager.js
@@ -388,7 +388,7 @@ define([
                 validatePageSettingsForm();
             });
 
-            $('body').on('click', '#dialog-dataSourceSettings .delete, #dialog-form-builder .delete', function() {
+            $('body').on('click', '#dialog-dataSourceSettings .delete', function() {
                 PubSub.publish(pubSubTable.showConfirmDialog, {
                     heading: 'Delete data source',
                     message: 'Are you sure you want to delete this data source?',


### PR DESCRIPTION
An errant copy/paste probably. The `#dialog-form-builder .delete` selector was used correctly, but added again.
