### PR TITLE
Deleting data source updates data source count in flyout menu

### DIFF
--- a/app/inst/www/js/site/site.js
+++ b/app/inst/www/js/site/site.js
@@ -280,6 +280,8 @@ define(['pages/page', 'data/dataSource', 'rcap/js/utils/pageWalker'/*, 'rcap/js/
             }));
 
             this.dataSources = dataSources;
+
+            return this;
         },
 
         updateDataSource : function(dataSource) {


### PR DESCRIPTION
`site`'s `deleteDataSourceID` wasn't returning `this`, meaning that calling function didn't have a return value to work with.
