### PR TITLE
Style editor can be launched without an existing rcap_designer.css asset

### DIFF
--- a/app/inst/www/js/assetManager.js
+++ b/app/inst/www/js/assetManager.js
@@ -30,7 +30,9 @@ define(['pubsub',
 
             PubSub.subscribe(pubSubTable.editTheme, function() {
                 // get the asset, show the dialog:
-                PubSub.publish(pubSubTable.showThemeEditorDialog, getNotebookAsset(themeAssetIdentifier).content());
+                var asset = getNotebookAsset(themeAssetIdentifier);
+
+                PubSub.publish(pubSubTable.showThemeEditorDialog, asset ? asset.content() : '');
             });
         };
 


### PR DESCRIPTION
Code was not accounting for an undefined return from `getNotebookAsset(...)`. This would occur if there was no existing `rcap_designer.css` file.

Guard statement introduced to counter this, set to `''` in the event of an undefined return.
