### PR TITLE
Full build works for new repo clones

### DIFF
--- a/inst/package.json
+++ b/inst/package.json
@@ -15,9 +15,7 @@
     "grunt-sass": "^1.2.1",
     "grunt-shell": "^1.1.2",
     "jshint-stylish": "^2.0.1",
-    "time-grunt": "^1.2.1"
-  },
-  "dependencies": {
-    "uglifyjs": "~2.4.10"
+    "time-grunt": "^1.2.1",
+    "uglifyjs": "2.4.10"
   }
 }


### PR DESCRIPTION
Moved `uglifyjs` to a dev dependency and removed the tilde from the version.

Turns out the later version of `uglifyjs` had been deprecated, so the sparklines make failed.