### PR TITLE
Execution order tweaks

### DIFF
--- a/inst/www/js/ui/dialogManager.js
+++ b/inst/www/js/ui/dialogManager.js
@@ -648,6 +648,12 @@ define([
                 $('#dialog-executionOrderSettings').jqmShow();
             });
 
+            $('#dialog-executionOrderSettings .clear').on('click', function() {
+                var inputs = $(this).closest('.jqmwindow').find('input');
+                inputs.val('');
+                inputs[0].focus();
+            });
+
             $('#dialog-executionOrderSettings .approve').on('click', function() {
 
                 // get data, send message:

--- a/inst/www/partials/dialogs/_executionOrderDialog.htm
+++ b/inst/www/partials/dialogs/_executionOrderDialog.htm
@@ -22,6 +22,7 @@
     </div>
     <div class="jqm-footer">
         <a href="javascript:void(0)" class="jqmClose">Cancel</a>
+        <a href="javascript:void(0)" class="clear">Clear</a>        
         <a href="javascript:void(0)" class="approve">Save</a>
     </div>
 </div>

--- a/inst/www/partials/dialogs/_executionOrderDialog.htm
+++ b/inst/www/partials/dialogs/_executionOrderDialog.htm
@@ -11,7 +11,7 @@
                 <thead>
                     <td>Page</td>
                     <td>Control type</td>
-                    <td>Code</td>
+                    <td>Function</td>
                     <td>Execution Order Hint</td>
                 </thead>
                 <tbody>


### PR DESCRIPTION
1. Changed 'code' heading to 'function';
2. 'Clear' button to clear execution order inputs.